### PR TITLE
FOGL-3077 Update for ThingSpeak

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,30 @@ This is a FogLAMP north plugin for talking to the MathWorks ThingSpeak
 web API. This allows buffered reading to be sent to the ThingSpeak API
 and further analysed in MATLAB. https://thingspeak.com
 
+Configuration
+-------------
+
+The following configuration options exist for the plugin
+
+url
+  The URL of the ThingSpeak API, this should normally be left as the default https://api.thingspeak.com/channels
+
+source
+  The source of data to send, either redings or statistics
+
+channelId
+  The ChannelID has setup in the ThingSpeak interface
+
+write_api_key
+  The write_api_key as obtained from the ThingSPeak interface
+
+fields
+  A defintion of the fields to be send. This is a JSON document with an
+  array called elements, each item in the array is a JSON object with
+  the properties asset and reading. Asset is the asset name and reading
+  is the datapoitn within the asset. The default for this element is an
+  example of how to send data fromthe siusoid plugin.
+
 Build
 -----
 To build FogLAMP "ThingSpeak" C++ filter plugin:

--- a/ThingSpeak.cpp
+++ b/ThingSpeak.cpp
@@ -148,19 +148,34 @@ ostringstream	payload;
 	}
 	payload << "]}";
 
-	char url[100];
-	snprintf(url, sizeof(url), "%s/%d/bulk_update.json", m_url.c_str(),
-			m_channel);
-
-	int errorCode;
-	if ((errorCode = m_https->sendRequest("POST", url, m_headers, payload.str())) == 200 || errorCode == 202)
+	if (first)
 	{
+		Logger::getLogger()->warn("ThingSpeak Nothing to send");
 		return readings.size();
 	}
 	else
 	{
+		char url[100];
+		snprintf(url, sizeof(url), "%s/%d/bulk_update.json", m_url.c_str(),
+				m_channel);
 
-		Logger::getLogger()->error("Failed to send to ThingSpeak %s, errorCode %d", url, errorCode);
-		return 0;
+		try {
+			int errorCode;
+			if ((errorCode = m_https->sendRequest("POST", url, m_headers, payload.str())) == 200 || errorCode == 202)
+			{
+				return readings.size();
+			}
+			else
+			{
+				Logger::getLogger()->error("Failed to send to ThingSpeak %s, errorCode %d", url, errorCode);
+			}
+		} catch (runtime_error& re) {
+			Logger::getLogger()->error("Failed to send to ThingSpeak %s, runtime error: %s", url, re.what());
+		} catch (exception& e) {
+			Logger::getLogger()->error("Failed to send to ThingSpeak %s, exception occured: %s", url, e.what());
+		} catch (...) {
+			Logger::getLogger()->error("Failed to send to ThingSpeak %s, unexpected exception occured", url);
+		}
 	}
+	return 0;
 }

--- a/ThingSpeak.cpp
+++ b/ThingSpeak.cpp
@@ -130,7 +130,7 @@ ostringstream	payload;
 						first = false;
 						outputDate = true;
 						payload << "{ \"created_at\": \"";
-						payload << (*it)->getAssetDateTime(Reading::FMT_ISO8601) << "\",";
+						payload << (*it)->getAssetDateUserTime(Reading::FMT_ISO8601) << "\",";
 					}
 					else
 					{

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -43,7 +43,7 @@ static const char *default_config = QUOTE({
 			"type": "string",
 			"default": PLUGIN_NAME,
 			"readonly": "true"
-			}
+			},
 		"URL": {
 			"description": "The URL of the ThingSpeak service",
 			"type": "string",

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -26,35 +26,61 @@ using namespace std;
 using namespace rapidjson;
 
 #define PLUGIN_NAME "ThingSpeak"
+#define FIELDS QUOTE({						\
+		"elements" : [					\
+			{					\
+				"asset" : "sinusoid",		\
+				"reading" : "sinusoid"		\
+			}					\
+			]})
+
 /**
  * Plugin specific default configuration
  */
-#define PLUGIN_DEFAULT_CONFIG "\"URL\": { " \
-				"\"description\": \"The URL of the ThingSpeak service\", " \
-				"\"type\": \"string\", " \
-				"\"default\": \"https://api.thingspeak.com/channels\", \"order\": \"1\", \"displayName\": \"URL\" }, " \
-			"\"source\": {" \
-				"\"description\": \"Defines the source of the data to be sent on the stream, " \
-				"this may be one of either readings, statistics or audit.\", \"type\": \"enumeration\", " \
-				"\"default\": \"readings\", "\
-				"\"options\": [\"readings\", \"statistics\"], \"order\": \"3\", \"displayName\": \"Source\"}, " \
-			"\"channelId\": { " \
-				"\"description\": \"The channel id for this thingSpeak channel\", " \
-				"\"type\": \"string\", \"default\": \"0\", \"order\": \"5\", \"displayName\": \"Channel ID\" }, " \
-			"\"write_api_key\": { " \
-				"\"description\": \"The write_api_key supplied by ThingSpeak for this channel\", " \
-				"\"type\": \"string\", \"default\": \"\", \"order\": \"2\", \"displayName\": \"API Key\" }, " \
-			"\"fields\": { " \
-				"\"description\": \"The fields to send ThingSpeak\", " \
-				"\"type\": \"JSON\", \"default\": \"{ " \
-				    "\\\"elements\\\":[" \
-				    "{ \\\"asset\\\":\\\"sinusoid\\\"," \
-				    "\\\"reading\\\":\\\"sinusoid\\\"}" \
-				"]}\", \"order\": \"4\", \"displayName\": \"Fields\" }"
+static const char *default_config = QUOTE({
+		"plugin": {
+			"description": "ThingSpeak North",
+			"type": "string",
+			"default": PLUGIN_NAME,
+			"readonly": "true"
+			}
+		"URL": {
+			"description": "The URL of the ThingSpeak service",
+			"type": "string",
+			"default": "https://api.thingspeak.com/channels",
+			"order": "1",
+			"displayName": "URL"
+			},
+		"source": {
+			"description": "Defines the source of the data to be sent on the stream",
+			"type": "enumeration",
+			"default": "readings",
+			"options": ["readings", "statistics"],
+		       	"order": "3",
+			"displayName": "Source"
+			},
+		"channelId": { 
+			"description": "The channel id for this thingSpeak channel",
+			"type": "string",
+			"default": "0",
+			"order": "5",
+			"displayName": "Channel ID"
+			},
+		"write_api_key": {
+			"description": "The write_api_key supplied by ThingSpeak for this channel",
+			"type": "string",
+			"default": "",
+			"order": "2","displayName": "API Key"
+			},
+		"fields": {
+			"description": "The fields to send ThingSpeak",
+			"type": "JSON",
+			"default": FIELDS,
+			"order": "4",
+			"displayName": "Fields"
+			}
+	});
 
-#define THINGSPEAK_PLUGIN_DESC "\"plugin\": {\"description\": \"ThingSpeak North\", \"type\": \"string\", \"default\": \"" PLUGIN_NAME "\", \"readonly\": \"true\"}"
-
-#define PLUGIN_DEFAULT_CONFIG_INFO "{" THINGSPEAK_PLUGIN_DESC ", " PLUGIN_DEFAULT_CONFIG "}"
 
 /**
  * The ThingSpeak plugin interface
@@ -70,7 +96,7 @@ static PLUGIN_INFORMATION info = {
 	0,				// Flags
 	PLUGIN_TYPE_NORTH,		// Type
 	"1.0.0",			// Interface version
-	PLUGIN_DEFAULT_CONFIG_INFO   	// Configuration
+	default_config			// Configuration
 };
 
 /**


### PR DESCRIPTION
The following changes

- User timestamp should now be used and not system timestamp
- Improved exception handling to catch all errors coming back from ThingSpeak and log them
- Moved to use the QUOTE macro for the configuration
- Updated the READ file